### PR TITLE
New Lookup Subjects resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,16 @@ SpiceDB connector depends on `symfony/serializer` and `symfony/http-client`. Ins
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use LinkORB\Authzed\Serializer\JsonLinesDecoder;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\UnwrappingDenormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
 
 new SpiceDB(
     new Serializer(
-        [new ArrayDenormalizer(), new ObjectNormalizer(null, null, null, new ReflectionExtractor())],
-        [new JsonEncoder()]
+        [new ArrayDenormalizer(), new UnwrappingDenormalizer(), new ObjectNormalizer(null, null, null, new ReflectionExtractor())],
+        [new JsonEncoder(), new JsonLinesDecoder()]
     ),
     HttpClient::create(),
     getenv('SPICEDB_HOST'),

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,11 @@
         <testsuite name="IntegrationCaveat">
             <file>tests/Integration/PermissionCaveatTest.php</file>
         </testsuite>
+        <testsuite name="IntegrationWithoutCaveatAndWatch">
+            <directory>./tests/Integration</directory>
+            <exclude>tests/Integration/WatchTest.php</exclude>
+            <exclude>tests/Integration/PermissionCaveatTest.php</exclude>
+        </testsuite>
     </testsuites>
 
     <coverage processUncoveredFiles="true">

--- a/src/ConnectorInterface.php
+++ b/src/ConnectorInterface.php
@@ -4,6 +4,7 @@ namespace LinkORB\Authzed;
 
 use Generator;
 use LinkORB\Authzed\Dto\Request\LookupResource as LookupResourceRequest;
+use LinkORB\Authzed\Dto\Request\LookupSubject as LookupSubjectRequest;
 use LinkORB\Authzed\Dto\Request\PermissionCheck as PermissionCheckRequest;
 use LinkORB\Authzed\Dto\Request\PermissionExpand as PermissionExpandRequest;
 use LinkORB\Authzed\Dto\Request\RelationshipDeletion as RelationshipDeletionRequest;
@@ -12,6 +13,7 @@ use LinkORB\Authzed\Dto\Request\RelationshipWrite as RelationshipWriteRequest;
 use LinkORB\Authzed\Dto\Request\Schema as SchemaRequest;
 use LinkORB\Authzed\Dto\Request\Watch as WatchRequest;
 use LinkORB\Authzed\Dto\Response\LookupResource as LookupResourceResponse;
+use LinkORB\Authzed\Dto\Response\LookupSubject as LookupSubjectResponse;
 use LinkORB\Authzed\Dto\Response\PermissionCheck as PermissionCheckResponse;
 use LinkORB\Authzed\Dto\Response\PermissionExpand as PermissionExpandResponse;
 use LinkORB\Authzed\Dto\Response\RelationshipDeletion as RelationshipDeletionResponse;
@@ -19,7 +21,6 @@ use LinkORB\Authzed\Dto\Response\RelationshipRead as RelationshipReadResponse;
 use LinkORB\Authzed\Dto\Response\RelationshipWrite as RelationshipWriteResponse;
 use LinkORB\Authzed\Dto\Response\Schema as SchemaResponse;
 use LinkORB\Authzed\Dto\Response\Watch as WatchResponse;
-use LinkORB\Authzed\Dto\Response\WatchResources as WatchResourcesResponse;
 
 interface ConnectorInterface
 {
@@ -27,9 +28,13 @@ interface ConnectorInterface
     public function writeSchema(SchemaRequest $request): void;
     public function checkPermission(PermissionCheckRequest $request): PermissionCheckResponse;
     public function expandPermission(PermissionExpandRequest $request): PermissionExpandResponse;
-    public function showResourcesPermission(LookupResourceRequest $request): LookupResourceResponse;
+    /** @return LookupResourceResponse[] */
+    public function showResourcesPermission(LookupResourceRequest $request): array;
+    /** @return LookupSubjectResponse[] */
+    public function showSubjectsPermission(LookupSubjectRequest $request): array;
     public function deleteRelationship(RelationshipDeletionRequest $request): RelationshipDeletionResponse;
-    public function readRelationship(RelationshipReadRequest $request): RelationshipReadResponse;
+    /** @return RelationshipReadResponse[] */
+    public function readRelationship(RelationshipReadRequest $request): array;
     public function writeRelationship(RelationshipWriteRequest $request): RelationshipWriteResponse;
     /** @return Generator|WatchResponse[] */
     public function watch(WatchRequest $request, float $abortIdleTimeout): Generator;

--- a/src/Dto/LookupResource.php
+++ b/src/Dto/LookupResource.php
@@ -2,7 +2,7 @@
 
 namespace LinkORB\Authzed\Dto;
 
-class Lookup
+class LookupResource
 {
     private ?ZedToken $lookedUpAt;
     private ?string $resourceObjectId;

--- a/src/Dto/LookupSubject.php
+++ b/src/Dto/LookupSubject.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace LinkORB\Authzed\Dto;
+
+class LookupSubject
+{
+    private ?ZedToken $lookedUpAt;
+    private ?string $subjectObjectId;
+
+    public function __construct(ZedToken $lookedUpAt = null, string $subjectObjectId = null)
+    {
+        $this->lookedUpAt      = $lookedUpAt;
+        $this->subjectObjectId = $subjectObjectId;
+    }
+
+    public function getLookedUpAt(): ?ZedToken
+    {
+        return $this->lookedUpAt;
+    }
+
+    public function getSubjectObjectId(): ?string
+    {
+        return $this->subjectObjectId;
+    }
+
+    public function setLookedUpAt(?ZedToken $lookedUpAt): self
+    {
+        $this->lookedUpAt = $lookedUpAt;
+        return $this;
+    }
+
+    public function setSubjectObjectId(?string $subjectObjectId): self
+    {
+        $this->subjectObjectId = $subjectObjectId;
+        return $this;
+    }
+}

--- a/src/Dto/Request/LookupSubject.php
+++ b/src/Dto/Request/LookupSubject.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+
+namespace LinkORB\Authzed\Dto\Request;
+
+use LinkORB\Authzed\Dto\Consistency;
+use LinkORB\Authzed\Dto\ObjectReference;
+
+class LookupSubject
+{
+    private ?Consistency $consistency;
+    private ?string $subjectObjectType;
+    private ?string $permission;
+    private ?ObjectReference $resource;
+    private ?string $optionalSubjectRelation;
+
+    public function __construct(
+        Consistency $consistency = null,
+        string $subjectObjectType = null,
+        string $permission = null,
+        ObjectReference $resource = null,
+        ?string $optionalSubjectRelation = null
+    ) {
+        $this->consistency                = $consistency;
+        $this->subjectObjectType          = $subjectObjectType;
+        $this->permission                 = $permission;
+        $this->resource                   = $resource;
+        $this->optionalSubjectRelation    = $optionalSubjectRelation;
+    }
+
+    public function getConsistency(): ?Consistency
+    {
+        return $this->consistency;
+    }
+
+    public function getSubjectObjectType(): ?string
+    {
+        return $this->subjectObjectType;
+    }
+
+    public function getPermission(): ?string
+    {
+        return $this->permission;
+    }
+
+    public function getResource(): ?ObjectReference
+    {
+        return $this->resource;
+    }
+
+    public function getOptionalSubjectRelation(): ?string
+    {
+        return $this->optionalSubjectRelation;
+    }
+
+    public function setConsistency(?Consistency $consistency): self
+    {
+        $this->consistency = $consistency;
+        return $this;
+    }
+
+    public function setSubjectObjectType(?string $subjectObjectType): self
+    {
+        $this->subjectObjectType = $subjectObjectType;
+        return $this;
+    }
+
+    public function setPermission(?string $permission): self
+    {
+        $this->permission = $permission;
+        return $this;
+    }
+
+    public function setResource(?ObjectReference $resource): self
+    {
+        $this->resource = $resource;
+        return $this;
+    }
+
+    public function setOptionalSubjectRelation(?string $optionalSubjectRelation): self
+    {
+        $this->optionalSubjectRelation = $optionalSubjectRelation;
+        return $this;
+    }
+}

--- a/src/Dto/Response/LookupSubject.php
+++ b/src/Dto/Response/LookupSubject.php
@@ -2,20 +2,20 @@
 
 namespace LinkORB\Authzed\Dto\Response;
 
-use LinkORB\Authzed\Dto\LookupResource as LookupResourceDto;
+use LinkORB\Authzed\Dto\LookupSubject as LookupSubjectDto;
 
-class LookupResource
+class LookupSubject
 {
-    private ?LookupResourceDto $result;
+    private ?LookupSubjectDto $result;
     private ?Error $error;
 
-    public function __construct(LookupResourceDto $result = null, Error $error = null)
+    public function __construct(LookupSubjectDto $result = null, Error $error = null)
     {
         $this->result = $result;
         $this->error  = $error;
     }
 
-    public function getResult(): ?LookupResourceDto
+    public function getResult(): ?LookupSubjectDto
     {
         return $this->result;
     }
@@ -25,7 +25,7 @@ class LookupResource
         return $this->error;
     }
 
-    public function setResult(?LookupResourceDto $result): self
+    public function setResult(?LookupSubjectDto $result): self
     {
         $this->result = $result;
         return $this;

--- a/src/Serializer/JsonLinesDecoder.php
+++ b/src/Serializer/JsonLinesDecoder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LinkORB\Authzed\Serializer;
+
+use Symfony\Component\Serializer\Encoder\JsonDecode;
+
+class JsonLinesDecoder extends JsonDecode
+{
+    public function decode(string $data, string $format, array $context = [])
+    {
+        $decodedData = [];
+
+        foreach (explode("\n", $data) as $line) {
+            if ($line === '') {
+                continue;
+            }
+
+            $decodedData[] = parent::decode($line, 'json', $context);
+        }
+
+        return $decodedData;
+    }
+
+    public function supportsDecoding(string $format)
+    {
+        return 'jsonl' === $format;
+    }
+}

--- a/tests/Integration/ErrorTest.php
+++ b/tests/Integration/ErrorTest.php
@@ -47,24 +47,6 @@ class ErrorTest extends TestCase
         }
     }
 
-    public function testWatchError(): void
-    {
-        $this->client->writeSchema(new SchemaRequest($this->getSchema()));
-
-        $watchRequest = new WatchRequest(['not-found-error']);
-
-        $this->expectException(SpiceDBServerException::class);
-
-        try {
-            iterator_to_array($this->client->watch($watchRequest, 0.1));
-        } catch (SpiceDBServerException $e) {
-            $this->assertEquals(3, $e->getError()->getCode());
-            $this->assertTrue(false !== strpos($e->getError()->getMessage(), 'value does not match regex pattern'));
-
-            throw $e;
-        }
-    }
-
     public function testInvalidSchemaError(): void
     {
         $this->expectException(SpiceDBServerException::class);

--- a/tests/Integration/SpicedbClientAwareTrait.php
+++ b/tests/Integration/SpicedbClientAwareTrait.php
@@ -2,12 +2,14 @@
 
 namespace LinkORB\Authzed\Tests\Integration;
 
+use LinkORB\Authzed\Serializer\JsonLinesDecoder;
 use LinkORB\Authzed\SpiceDB;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Normalizer\UnwrappingDenormalizer;
 use Symfony\Component\Serializer\Serializer;
 
 trait SpicedbClientAwareTrait
@@ -16,8 +18,8 @@ trait SpicedbClientAwareTrait
     {
         return new SpiceDB(
             new Serializer(
-                [new ArrayDenormalizer(), new ObjectNormalizer(null, null, null, new ReflectionExtractor())],
-                [new JsonEncoder()]
+                [new ArrayDenormalizer(), new UnwrappingDenormalizer(), new ObjectNormalizer(null, null, null, new ReflectionExtractor())],
+                [new JsonEncoder(), new JsonLinesDecoder()]
             ),
             HttpClient::create(),
             getenv('SPICEDB_HOST'),


### PR DESCRIPTION
## Proposed changes

1. Just add `/v1/permissions/subjects` API endpoint support with tests
2. Add JsonLines https://jsonlines.org/ responses support #1 
3. Reorganized tests (WatchErrorTest moved to WatchTest File)
4. Handling two types of error responses:

**Error Response 1 Example:**
```json
{
    "error": {
        "code": 3,
        "message": "invalid LookupSubjectsRequest.Resource: embedded message failed validation | caused by: invalid ObjectReference.ObjectType: value does not match regex pattern \"^([a-z][a-z0-9_]{1,61}[a-z0-9]/)?[a-z][a-z0-9_]{1,62}[a-z0-9]$\"; invalid ObjectReference.ObjectId: value does not match regex pattern \"^(([a-zA-Z0-9/_|\\\\-=+]{1,})|\\\\*)$\"",
        "details": []
    }
}
```

**Error Response 2  Example:**
```json
{
    "code": 2,
    "message": "could not CREATE relationship `blog/post:mypost-to-show-subject#writer@blog/user:john`, as it already existed. If this is persistent, please switch to TOUCH operations or specify a precondition",
    "details": []
}
```

## Types of changes

- [x] feat: breaking change which adds new functionality
- [ ] fix: non-breaking change which fixes a bug or an issue
- [ ] chore(deps): changes to dependencies
- [x] test: adds or modifies a test
- [x] docs: creates or updates documentation
- [ ] style: changes that do not affect the meaning or function of code (e.g. formatting, whitespace, missing semi-colons etc.)
- [ ] perf: code change that improves performance
- [ ] revert: reverts a commit
- [x] refactor: code change that neither fix a bug nor add a new feature
- [ ] ci: changes to continuous integration or continuous delivery scripts or configuration files
- [ ] chore: general tasks or anything that doesn't fit the other commit types

### Breaking changes:

- [x] Breaking change: new serializer Decoder and UnwrappingDenormalizer used.
- [x] Changed interface for 2 old methods: `showResourcesPermission` and `readRelationship`
- [x] Renamed  `LinkORB\Authzed\Dto\Lookup` to `LinkORB\Authzed\Dto\LookupResource`

## Checklist

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
